### PR TITLE
Ignore all function parameters option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# unused
+# unused [![Build Status](https://secure.travis-ci.org/Kami/node-unused.png?branch=master)](https://travis-ci.org/Kami/node-unused)
 
 Identify unused variables in your javascript code.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# unused [![Build Status](https://secure.travis-ci.org/Kami/node-unused.png?branch=master)](https://travis-ci.org/Kami/node-unused)
+# unused
 
 Identify unused variables in your javascript code.
 
@@ -16,15 +16,29 @@ Comma separated list of function parameters to ignore during unused checks. You 
 $ unused /path/to/file.js --ignore-params req,res,_
 ```
 
+### --ignore-all-params
+
+A flag to ignore all function parameters during unused checks. If you're working in a large project, there are usually many unused function parameters that are simply placeholders to get to later parameters, so this options allows you to turn off this warning altogether.
+
+```shell
+$ unused /path/to/file.js --ignore-all-params
+```
+
 ## api
 
-### unused(src)
+### unused(src, options)
 
 > src is a javascript source string
 
+> options is an object containing configuration. like the following:
+```javascript
+{ ignore_all_params: true }
+```
+
+
 Returns an array of objects specifying the name, location, and if the variable is a function parameter
 
-```
+```javascript
 {
     name: 'foo',
     loc: {

--- a/bin/unused
+++ b/bin/unused
@@ -6,6 +6,8 @@ var argv = require('optimist')
     .usage('Usage: unused <file>')
     .describe('ignore-params', 'comma separated list of unused function parameters to ignore')
     .describe('ignore-all-params', 'flag to ignore all function parameters')
+    .boolean('ignore-all-params')
+    .default('ignore-all-params', false)
     .argv;
 
 var unused = require('../');

--- a/bin/unused
+++ b/bin/unused
@@ -5,17 +5,21 @@ var fs = require('fs');
 var argv = require('optimist')
     .usage('Usage: unused <file>')
     .describe('ignore-params', 'comma separated list of unused function parameters to ignore')
+    .describe('ignore-all-params', 'flag to ignore all function parameters')
     .argv;
 
 var unused = require('../');
 
 var ignore_params = (argv['ignore-params'] || '').split(',');
+var ignore_all_params = !!argv['ignore-all-params'];
 
 var errors = 0;
 argv._.forEach(function(path) {
 
     try {
-        var unused_vars = unused(fs.readFileSync(path, 'utf8'));
+        var unused_vars = unused(fs.readFileSync(path, 'utf8'), {
+            ignore_all_params: ignore_all_params
+        });
     }
     catch (e) {
         return console.dir(e);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,10 @@ var esprima = require('esprima');
 var Context = require('./lib/context');
 
 // return a list of unused variables in the source
-function unused(src) {
+function unused(src, options) {
+    var options = options || {};
+    var ignore_all_params = !!options.ignore_all_params;
+
     var ast = esprima.parse(src, {
         loc: true
     });
@@ -38,7 +41,9 @@ function unused(src) {
     }
 
     function maybe_set_param(id, context) {
-        maybe_set_id(id, context, true);
+        if(!ignore_all_params) {
+            maybe_set_id(id, context, true);
+        }
     }
 
     var handlers = {


### PR DESCRIPTION
Just whipped up a little patch to allow users to turn off function parameter testing, since it forces a lot of false positives, and isn't a bad practice in and of itself. Here's an example:

``` javascript
function (foo, bar) {
    console.log(bar);
}
```

You need to have `foo` declared so you can address `bar` whether or not you need `foo`.

Now, if you pass `--ignore-all-parameters` into the CLI, the unused function will ignore all unused function parameters.

_Update after some discussion on earlier pull request_
